### PR TITLE
Fix name typos for NavPage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,8 +148,8 @@ add_executable(${PROJECT_NAME}
         ui/mydata/Files.ui
         ui/mydata/FileInfoListModel.cpp
         ui/mydata/FileInfoListModel.hpp
-        ui/mydata/Navpage.cpp
-        ui/mydata/Navpage.hpp
+        ui/mydata/NavPage.cpp
+        ui/mydata/NavPage.hpp
         ui/mydata/NavPage.ui
         ui/mydata/DriveInfo.cpp
         ui/mydata/DriveInfo.hpp

--- a/ui/mydata/NavPage.cpp
+++ b/ui/mydata/NavPage.cpp
@@ -5,7 +5,7 @@
 // You may need to build the project (run Qt uic code generator) to get "ui_Navpage.h" resolved
 
 #include "NavPage.hpp"
-#include "ui_Navpage.h"
+#include "ui_NavPage.h"
 
 #include <QColumnView>
 #include <QLayout>


### PR DESCRIPTION
Trying to build for RPi5 within a podman build container, I hit this issue running Cmake and early make/build stage.