### PR TITLE
Fix QObject inheritance and guard configuration checks

### DIFF
--- a/AppItem.cpp
+++ b/AppItem.cpp
@@ -23,17 +23,6 @@ namespace fairwindsk {
 /*
  * Public Constructor
  */
-    AppItem::AppItem(const fairwindsk::AppItem &app) {
-
-        // Retrieve the app's infos from the provided App instance
-        m_jsonApp = app.m_jsonApp;
-
-
-    }
-
-/*
- * Public Constructor
- */
     AppItem::AppItem(nlohmann::json jsonApp) {
 
         // Get the app's infos and store them for future usage

--- a/AppItem.hpp
+++ b/AppItem.hpp
@@ -16,7 +16,7 @@ namespace fairwindsk::ui::web { class Web; }
 
 namespace fairwindsk {
 
-    class AppItem: QObject {
+    class AppItem: public QObject {
         Q_OBJECT
 
 
@@ -29,7 +29,8 @@ namespace fairwindsk {
             // Destructor
             ~AppItem() override;
 
-            AppItem(const AppItem &app);
+            AppItem(const AppItem &app) = delete;
+            AppItem &operator=(const AppItem &app) = delete;
 
             void update(const nlohmann::json&  jsonApp);
 

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -84,7 +84,7 @@ namespace fairwindsk {
 
         if (m_jsonData.contains("connection") && m_jsonData["connection"].is_object()) {
             auto connectionJsonObject = m_jsonData["connection"];
-            if (connectionJsonObject.contains("server") & connectionJsonObject["server"].is_string()) {
+            if (connectionJsonObject.contains("server") && connectionJsonObject["server"].is_string()) {
                 signalKServerUrl = QString::fromStdString(connectionJsonObject["server"].get<std::string>());
             }
         }
@@ -150,7 +150,7 @@ namespace fairwindsk {
         bool result = false;
 
         if (m_jsonData.contains("main")) {
-            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("virtualKeyboard") & mainJsonObject["virtualKeyboard"].is_boolean()) {
+            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("virtualKeyboard") && mainJsonObject["virtualKeyboard"].is_boolean()) {
                 result = mainJsonObject["virtualKeyboard"].get<bool>();
             }
         }
@@ -168,7 +168,7 @@ namespace fairwindsk {
         QString result = "windowed";
 
         if (m_jsonData.contains("main")) {
-            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowMode") & mainJsonObject["windowMode"].is_string()) {
+            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowMode") && mainJsonObject["windowMode"].is_string()) {
                 result = QString::fromStdString(mainJsonObject["windowMode"].get<std::string>());
             }
         }
@@ -180,7 +180,7 @@ namespace fairwindsk {
         int result = 0;
 
         if (m_jsonData.contains("main")) {
-            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowWidth") & mainJsonObject["windowWidth"].is_number_integer()) {
+            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowWidth") && mainJsonObject["windowWidth"].is_number_integer()) {
                 result = mainJsonObject["windowWidth"].get<int>();
             }
         }
@@ -198,7 +198,7 @@ namespace fairwindsk {
         int result = 0;
 
         if (m_jsonData.contains("main")) {
-            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowHeight") & mainJsonObject["windowHeight"].is_number_integer()) {
+            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowHeight") && mainJsonObject["windowHeight"].is_number_integer()) {
                 result = mainJsonObject["windowHeight"].get<int>();
             }
         }
@@ -216,7 +216,7 @@ namespace fairwindsk {
         int result = 0;
 
         if (m_jsonData.contains("main")) {
-            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowLeft") & mainJsonObject["windowLeft"].is_number_integer()) {
+            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowLeft") && mainJsonObject["windowLeft"].is_number_integer()) {
                 result = mainJsonObject["windowLeft"].get<int>();
             }
         }
@@ -234,7 +234,7 @@ namespace fairwindsk {
         int result = 0;
 
         if (m_jsonData.contains("main")) {
-            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowTop") & mainJsonObject["windowTop"].is_number_integer()) {
+            if (auto mainJsonObject = m_jsonData["main"]; mainJsonObject.contains("windowTop") && mainJsonObject["windowTop"].is_number_integer()) {
                 result = mainJsonObject["windowTop"].get<int>();
             }
         }
@@ -263,7 +263,7 @@ namespace fairwindsk {
 
         if (m_jsonData.contains("main")) {
             auto mainJsonObject = m_jsonData["main"];
-            if (mainJsonObject.contains("autopilot") & mainJsonObject["autopilot"].is_string()) {
+            if (mainJsonObject.contains("autopilot") && mainJsonObject["autopilot"].is_string()) {
                 result = QString::fromStdString(mainJsonObject["autopilot"].get<std::string>());
             }
         }
@@ -277,7 +277,7 @@ namespace fairwindsk {
         if (m_jsonData.contains("units")) {
             auto unitsJsonObject = m_jsonData["units"];
             auto unitsKey = units.toStdString();
-            if (unitsJsonObject.contains(unitsKey) & unitsJsonObject[unitsKey].is_string()) {
+            if (unitsJsonObject.contains(unitsKey) && unitsJsonObject[unitsKey].is_string()) {
                 result = unitsJsonObject[unitsKey].get<std::string>();
             }
         }

--- a/FairWindSK.cpp
+++ b/FairWindSK.cpp
@@ -235,7 +235,7 @@ namespace fairwindsk {
         bool result = false;
 
         // Get the configuration root JSON object
-        auto configurationJsonObject = m_configuration.getRoot();
+        auto &configurationJsonObject = m_configuration.getRoot();
 
         // Check if apps is not defined in configuration
         if (!configurationJsonObject.contains("apps")) {
@@ -643,4 +643,3 @@ namespace fairwindsk {
     }
 
 }
-

--- a/signalk/Client.cpp
+++ b/signalk/Client.cpp
@@ -789,7 +789,7 @@ namespace fairwindsk::signalk {
     }
 
     QUrl Client::getEndpointByProtocol(const QString &protocol, const QString& version) {
-        if (m_Server.contains("endpoints") & m_Server["endpoints"].isObject()) {
+        if (m_Server.contains("endpoints") && m_Server["endpoints"].isObject()) {
             auto jsonObjectEndponts = m_Server["endpoints"].toObject();
             if (jsonObjectEndponts.contains(version) && jsonObjectEndponts[version].isObject()) {
                 auto jsonObjectVersion = jsonObjectEndponts[version].toObject();


### PR DESCRIPTION
## Summary
- make AppItem a proper QObject by using public inheritance and disallowing copies
- use references and logical checks when reading configuration to avoid unintended mutations
- guard endpoint lookup with correct logical operator in Signal K client

## Testing
- Not run (Qt build environment not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950620372d4832d8c681d02508d676a)