### PR TITLE
Add documentation set and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ It runs on Mac, Linux, and Raspberry Pi OS. It probably works on Windows, too, b
 I’d like to port it under Android and iOS QT Apps with the same source approach, but for now, I’m focused on
 stabilizing it on the already supported platforms.
 
+## Documentation
+
+* [Getting started](docs/getting_started.md)
+* [Architecture overview](docs/architecture.md)
+* [Configuration guide](docs/configuring.md)
+* [GUI tour](docs/gui.md)
+* [Typical use cases](docs/use_case.md)
+
 ![The FairWindSK desktop](images/fairwindsk-desktop.png)
 
 ### Stable components ###

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,29 @@
+# FairWindSK architecture
+
+FairWindSK is a Qt6 desktop shell that launches Signal K web applications and exposes native bars for vessel operations. The core is written in C++17 and organized around a small set of classes that manage configuration, networking, and UI composition.
+
+## High-level components
+
+- **Application bootstrap (`main.cpp`)**: Initializes Qt, installs translations, shows the splash screen, and hands control to the `FairWindSK` singleton before opening the main window. It sets up default WebEngine features such as accelerated canvas and plugin support.
+- **Singleton core (`FairWindSK`)**: Central orchestrator that loads configuration, negotiates the Signal K connection, synchronizes installed web apps, and exposes global services (the shared `QWebEngineProfile`, the `signalk::Client`, and the app registry).
+- **Configuration management (`Configuration`)**: Loads and saves `fairwindsk.json`, seeds defaults from `resources/json/configuration.json`, and persists user choices (window geometry, unit preferences, application list, and plugin-specific settings). Token storage lives in `fairwindsk.ini` via `QSettings`.
+- **Application registry (`AppItem`)**: Represents a web or local application, including metadata (name, description, icon), activation state, ordering, and optional settings/help/about URLs. Items are refreshed from the Signal K server’s `/skServer/webapps` listing and merged with local overrides.
+- **Signal K client (`signalk::Client`)**: Manages websocket communication with the server using URLs derived from `connection.server` plus `/signalk`, including authentication tokens shared through the WebEngine cookie store.
+- **UI layers (`ui/` directory)**: Implements the Qt widgets for the desktop, top/bottom bars, settings panels, and embedded web views. Bars read the `Configuration` paths (e.g., `navigation.anchor.*`, autopilot targets) to bind to Signal K data.
+
+## Data and configuration flow
+
+1. **Startup**: `FairWindSK::loadConfig()` reads `fairwindsk.ini` for the JSON configuration path and debug flag, then loads or seeds `fairwindsk.json`.
+2. **Server connection**: `FairWindSK::startSignalK()` builds parameters from the configuration and attempts websocket connectivity, persisting any returned token back to `fairwindsk.ini`.
+3. **Application discovery**: `FairWindSK::loadApps()` requests `/skServer/webapps` from the configured server. Each returned entry tagged with `signalk-webapp` becomes an `AppItem`. Local apps in `fairwindsk.json` are merged, preserving order and activation. Inactive or missing server apps are demoted but retained.
+4. **UI initialization**: The main window consumes the `AppItem` registry to populate the desktop. Bars subscribe to Signal K paths defined in `resources/json/configuration.json`, matching autopilot, anchor, POB, and alarm data fields.
+
+## Authentication model
+
+Tokens are stored outside the main JSON configuration to avoid accidental check-in. `Configuration::getToken()` and `setToken()` read/write `fairwindsk.ini`, while `FairWindSK` injects the token into the shared `QWebEngineProfile` cookie store as `JAUTHENTICATION`. Web apps launched through the profile reuse this authentication context.
+
+## Extending the application
+
+- **Adding custom web apps**: Insert entries under `apps` in `fairwindsk.json` with `name` pointing to an HTTPS, HTTP, or `file://` URL. Provide `signalk.appIcon` and `signalk.displayName` to control the tile presentation.
+- **Integrating native features**: Bars and custom widgets should consume data paths already listed under the `signalk` block in `resources/json/configuration.json` or add new keys that map to Signal K paths.
+- **Platform adaptations**: The singleton exposes window sizing and mode fields (fullscreen vs. windowed). On embedded platforms, adjust these in `fairwindsk.json` to match the display resolution and desired kiosk behavior.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1,0 +1,102 @@
+# Configuring FairWindSK
+
+FairWindSK stores its runtime settings in `fairwindsk.json`, with the location recorded in `fairwindsk.ini` (managed by Qt). If the JSON file is missing, defaults are copied from the embedded `resources/json/configuration.json`.
+
+## Configuration files
+
+- **`fairwindsk.json`**: Main user-editable configuration containing connection details, app definitions, UI geometry, and unit preferences.
+- **`fairwindsk.ini`**: Qt-managed settings that track the JSON file path (`config`), the debug flag, and the last authentication token (`token`).
+- **`resources/json/configuration.json`**: Bundled defaults used to seed a new installation.
+
+## Connection settings
+
+```jsonc
+{
+  "connection": {
+    "server": "http://your-signalk-host:3000"
+  }
+}
+```
+
+- `server`: Base URL of the Signal K server. The application appends `/signalk` for websocket data and `/skServer/webapps` for application discovery. Leave this empty to start offline; the desktop loads but no remote apps will appear.
+
+## Application definitions
+
+Applications live under the `apps` array. Each entry represents a web or local app:
+
+```jsonc
+{
+  "name": "https://spotify.com",
+  "description": "Spotify web application",
+  "fairwind": {
+    "active": true,
+    "order": 990
+  },
+  "signalk": {
+    "appIcon": "file://icons/spotify_icon.png",
+    "displayName": "Spotify",
+    "aboutUrl": "",
+    "settingsUrl": "",
+    "helpUrl": ""
+  }
+}
+```
+
+- `name`: URL for the app (supports `https://`, `http://`, and `file://` for local desktop tools like OpenCPN).
+- `fairwind.active`: Whether the app tile is shown.
+- `fairwind.order`: Ordering on the desktop (lower numbers appear first).
+- `signalk.*`: Presentation metadata used by the UI. Icon paths support Qt resource prefixes (`:/resources/...`) or filesystem URLs.
+
+Apps discovered from the Signal K server (`signalk-webapp` entries) are merged with this list during startup. Local overrides for ordering and activation are preserved.
+
+## Units and data paths
+
+`resources/json/configuration.json` defines the default Signal K data paths and units. You can override these in `fairwindsk.json`:
+
+```jsonc
+{
+  "units": {
+    "vesselSpeed": "kn",
+    "windSpeed": "kn",
+    "distance": "nm",
+    "range": "rm",
+    "depth": "mt"
+  },
+  "signalk": {
+    "sog": "navigation.speedOverGround",
+    "stw": "navigation.speedThroughWater",
+    "hdg": "navigation.headingTrue"
+  }
+}
+```
+
+These mappings drive UI bars (autopilot, anchor, alarms, POB) and instrument readouts. Ensure any custom paths exist on your Signal K server.
+
+## Window and input settings
+
+```jsonc
+{
+  "main": {
+    "windowMode": "windowed", // or "fullscreen"
+    "windowWidth": 1024,
+    "windowHeight": 600,
+    "windowLeft": 0,
+    "windowTop": 20,
+    "virtualKeyboard": false,
+    "autopilot": ""
+  }
+}
+```
+
+- `windowMode`: Choose `windowed` or `fullscreen` (useful for kiosk deployments).
+- `windowWidth/Height/Left/Top`: Window geometry when not fullscreen.
+- `virtualKeyboard`: Enables the Qt virtual keyboard module if available.
+- `autopilot`: Default autopilot identifier for widgets that target a specific device.
+
+## Authentication and tokens
+
+Authentication tokens are stored in `fairwindsk.ini` under the `token` key and injected into the shared `QWebEngineProfile` cookie store as `JAUTHENTICATION`. This keeps sensitive credentials out of the JSON configuration. To reset authentication, remove the token from `fairwindsk.ini` and relaunch.
+
+## Debugging
+
+Set `debug=true` in `fairwindsk.ini` to enable verbose logging from the Signal K client, configuration loader, and application discovery routines. Debug mode also enables additional Qt WebEngine logging categories.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,45 @@
+# Getting started with FairWindSK
+
+FairWindSK is a Qt6-based desktop that launches and supervises Signal K web applications, plus a handful of native bars (autopilot, anchor, person overboard, alarms, and status overlays). The application is written in C++17, uses Qt WebEngine for rendering, and connects directly to a running Signal K server to discover installed web apps.
+
+## Prerequisites
+
+- A running Signal K server reachable on the network. The client expects the standard API to be exposed at `<server>/signalk` and the web application catalog at `<server>/skServer/webapps`.
+- Qt 6 with WebEngine, WebSockets, SVG, and VirtualKeyboard modules (see the package list in the root README for Linux and macOS examples). A C++17 compiler and CMake are required for builds from source.
+- Optional: desktop environments that support global hotkeys if you rely on the SHIFT+TAB shortcut to return to the FairWindSK desktop after launching a web app.
+
+## Building from source
+
+The project uses a conventional CMake workflow. The steps below mirror the platform instructions in the root README and work across macOS, Linux, and Raspberry Pi OS.
+
+1. Install Qt6 and the build toolchain (CMake, a C++17 compiler, and the Qt6 WebEngine, WebSockets, SVG, and VirtualKeyboard components).
+2. Clone the repository and create a build directory:
+   ```bash
+   git clone https://github.com/OpenFairWind/FairWindSK.git
+   cd FairWindSK
+   cmake -S . -B build
+   cmake --build build
+   ```
+3. On Raspberry Pi OS you may need to create `/usr/lib/aarch64-linux-gnu/cmake/Qt6VirtualKeyboard/Qt6VirtualKeyboardConfigVersionImpl.cmake` before configuring, matching the workaround in the main README.
+4. The resulting executable is `build/FairWindSK` (or `FairWindSK.exe` on Windows builds).
+
+## First run and configuration bootstrap
+
+1. Launch the binary. On first run the app reads `fairwindsk.ini` (created in the working directory by Qt) to determine the configuration file path and debug flag. If no path is stored, it defaults to `fairwindsk.json` beside the executable.
+2. If the JSON configuration file does not exist, the application seeds its settings from the bundled `resources/json/configuration.json`, preserving defaults such as UI sizing, unit choices, and a starter app list.
+3. Point the client at your Signal K server by editing the `connection.server` field in `fairwindsk.json` or by letting a platform integration layer provide the file.
+4. FairWindSK connects to the server, negotiates a token if available, and persists the token in `fairwindsk.ini` for subsequent launches.
+5. Discovered Signal K web applications are merged into the local configuration, preserving local overrides (ordering, activation state, and custom icons). Web apps and locally defined URLs (including `file://` entries for native tools such as OpenCPN) appear on the desktop.
+
+## Running the desktop
+
+- Start the application normally from the build output folder or after installing it into your system path. On Raspberry Pi OS the project includes a sample autostart entry in `extras/fairwindsk-startup.desktop` and a helper script in `extras/fairwindsk-startup`.
+- The splash screen shows connection progress while the Signal K client initializes and downloads the web app catalog.
+- Once the main window appears, use the desktop tiles to launch apps. SHIFT+TAB brings you back to the FairWindSK desktop when a web app takes full focus.
+- The bottom bars expose quick controls for alarms, person overboard, anchor, and autopilot features. Availability depends on the configured Signal K data paths and installed plugins.
+
+## Troubleshooting
+
+- If no applications appear, verify the `connection.server` URL and that the Signal K server exposes `/skServer/webapps`.
+- Enable debug logging by setting `debug=true` in `fairwindsk.ini` before launching. Logs include connection attempts and application discovery details.
+- Check that your platform has Qt WebEngine acceleration enabled; `QWebEngineSettings::Accelerated2dCanvasEnabled` is turned on by default at runtime.

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,0 +1,34 @@
+# Graphical user interface overview
+
+FairWindSK presents a desktop-style grid of applications backed by Qt6 widgets and Qt WebEngine views. Native bars along the top and bottom provide quick vessel controls and status.
+
+## Desktop and navigation
+
+- **Application grid**: Tiles correspond to `AppItem` entries discovered from the Signal K server or defined locally. Icons and labels come from the `signalk` metadata block (e.g., `displayName`, `appIcon`).
+- **Focus management**: When a web app takes over the view, press `SHIFT+TAB` to return to the FairWindSK desktop.
+- **Icons and resources**: Icons can reference Qt resources (`:/resources/...`) or filesystem paths (`file://icons/...`). Ensure any new assets are registered in `resources.qrc` if bundled.
+
+## Top and bottom bars
+
+- **Top bar**: Provides quick status indicators and access points to settings depending on the active view.
+- **Bottom bars**: Dedicated widgets for:
+  - **Autopilot**: Shows autopilot state, target heading/wind angle, and rudder information using paths from the `signalk` configuration block.
+  - **Anchor**: Displays anchor position, radius, rode length, and actions such as drop, raise, and radius adjustments (mapped to plugin action paths).
+  - **POB (Person over board)**: Drops a waypoint, sets it as destination, and shows bearing/distance/time from the incident position.
+  - **Alarms**: Surfaces Signal K notifications (e.g., fire, piracy, abandon, sinking) and the anchor alarm state.
+
+Availability of these bars depends on the configured plugin identifiers (`applications.autopilot`, `applications.anchor`) and the presence of the corresponding Signal K data paths.
+
+## Settings and configuration UI
+
+- The settings pane reads from `fairwindsk.json` to manage the application list, ordering, and activation. Server-discovered apps are merged with local overrides, and changes are saved back to the configuration.
+- Unit selection, window sizing, and virtual keyboard toggles are reflected in the `main` and `units` sections of the configuration.
+
+## Splash and status messages
+
+- On startup, a splash screen shows progress as the application loads configuration, connects to Signal K, and fetches the web app catalog. Messages mirror the lifecycle in `main.cpp`.
+
+## Accessibility and input
+
+- **Virtual keyboard**: If `main.virtualKeyboard` is true and the Qt VirtualKeyboard module is available, the on-screen keyboard becomes available for touch-only deployments.
+- **Keyboard shortcuts**: Use `SHIFT+TAB` to exit an active web app session and return to the desktop; other shortcuts may be provided by individual web apps.

--- a/docs/use_case.md
+++ b/docs/use_case.md
@@ -1,0 +1,30 @@
+# Typical use cases
+
+FairWindSK provides a kiosk-like desktop for running Signal K web applications alongside native controls. Below are common workflows that align with the current feature set.
+
+## Navigation dashboard with Signal K apps
+
+- Connect FairWindSK to a vessel’s Signal K server and let it discover installed web apps such as Freeboard-SK or KIP through `/skServer/webapps`.
+- Use the desktop tiles to launch each app in its own web view. SHIFT+TAB returns focus to the FairWindSK desktop when a web app occupies the screen.
+- Keep the bottom bars visible for quick access to alarms, person overboard recovery, anchor status, and autopilot state.
+
+## Mixed local and remote applications
+
+- Add local navigation tools (e.g., OpenCPN) using `file://` URLs in `fairwindsk.json`. Provide custom icons and display names through the `signalk` metadata block.
+- Combine these with remote web apps from the Signal K catalog; ordering is controlled via the `fairwind.order` field so both local and server-hosted tools appear in one grid.
+
+## Autopilot and anchor workflows
+
+- Configure the autopilot and anchor plugin identifiers in `fairwindsk.json` under `applications.autopilot` and `applications.anchor`. The bottom bars check these entries to decide whether to expose controls.
+- Map the relevant Signal K paths (rudder angle, target heading, anchor radius, alarms) in the `signalk` section so UI widgets display live data and actions.
+
+## Onboard file and data management
+
+- Use the “MyData” components to browse Signal K resources such as waypoints, tracks, routes, and files when the corresponding server plugins are available.
+- The file browser and viewers handle images, PDFs, and text when delivered through the server’s resource endpoints.
+
+## Embedded and kiosk deployments
+
+- Set `main.windowMode` to `fullscreen` and adjust window geometry for the target display resolution in `fairwindsk.json`.
+- Enable the Qt virtual keyboard via `main.virtualKeyboard=true` for touch-only installations.
+- Utilize the provided autostart entries (`extras/fairwindsk-startup.desktop` and `extras/fairwindsk-startup`) on Raspberry Pi OS to launch at boot.


### PR DESCRIPTION
## Summary
- add user-facing documentation covering getting started, architecture, configuration, UI, and use cases
- link the new docs from the main README for easy navigation

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695071d5fb18832d89436e58716d3496)